### PR TITLE
classification() add image type Image.Image and pathlib.Path

### DIFF
--- a/ddddocr/__init__.py
+++ b/ddddocr/__init__.py
@@ -6,6 +6,7 @@ import io
 import os
 import base64
 import json
+import pathlib
 import onnxruntime
 from PIL import Image, ImageChops
 import numpy as np
@@ -1594,13 +1595,20 @@ class DdddOcr(object):
             return []
         return result
 
-    def classification(self, img_bytes: bytes = None, img_base64: str = None):
+    def classification(self, img):
         if self.det:
             raise TypeError("当前识别类型为目标检测")
-        if img_bytes:
-            image = Image.open(io.BytesIO(img_bytes))
+        if not isinstance(img, (bytes, str, pathlib.PurePath, Image.Image)):
+            raise TypeError("未知图片类型")
+        if isinstance(img, bytes):
+            image = Image.open(io.BytesIO(img))
+        elif isinstance(img, Image.Image):
+            image = img.copy()
+        elif isinstance(img, str):
+            image = base64_to_image(img)
         else:
-            image = base64_to_image(img_base64)
+            assert isinstance(img, pathlib.PurePath)
+            image = Image.open(img)
         if not self.use_import_onnx:
             image = image.resize((int(image.size[0] * (64 / image.size[1])), 64), Image.ANTIALIAS).convert('L')
         else:


### PR DESCRIPTION
classification()函数的图片参数新增两种类型：Image.Image 及 pathlib.Path
方便直接识别屏幕截图，直接内存传输图片以避免磁盘操作。
以及简化磁盘图片的识别加载过程。

用法示例一，屏幕坐标抓图直接识别：
```python3
import ddddocr
from PIL import ImageGrab
vcode_ocr = ddddocr.DdddOcr()
img_vcode = ImageGrab.grab((20, 60, 100, 100), all_screens=True)
v = vcode_ocr.classification(img_vcode)
print(v)

```
输出
```
96BA

```
用法示例二，识别目录中全部图片：
```python3
import ddddocr
from pathlib import Path
vcode_ocr = ddddocr.DdddOcr()
for filename in Path('z:\\t').glob(r'**/*'):
    if not filename.suffix.lower() in ('.png','.jpg'):
        continue
    v = vcode_ocr.classification(filename)
    print(f'{v}\t{str(filename)}')

```
输出
```
2a3ny   z:\t\2a3ny.jpg
6FKU    z:\t\6FKU.png
5GNV    z:\t\5GNV.png

```
示例三，以前的单文件识别示例可简化为3行
```python3
import ddddocr
from pathlib import Path
print(ddddocr.DdddOcr().classification(Path('z:/t/2a3ny.jpg'))
```
输出
`2a3ny`