### PR TITLE
Use the newer API Update __init__.py

### DIFF
--- a/ddddocr/__init__.py
+++ b/ddddocr/__init__.py
@@ -2567,16 +2567,16 @@ class DdddOcr(object):
             assert isinstance(img, pathlib.PurePath)
             image = Image.open(img)
         if not self.use_import_onnx:
-            image = image.resize((int(image.size[0] * (64 / image.size[1])), 64), Image.ANTIALIAS).convert('L')
+            image = image.resize((int(image.size[0] * (64 / image.size[1])), 64), Image.Resampling.LANCZOS).convert('L')
         else:
             if self.__resize[0] == -1:
                 if self.__word:
-                    image = image.resize((self.__resize[1], self.__resize[1]), Image.ANTIALIAS)
+                    image = image.resize((self.__resize[1], self.__resize[1]), Image.Resampling.LANCZOS)
                 else:
                     image = image.resize((int(image.size[0] * (self.__resize[1] / image.size[1])), self.__resize[1]),
-                                         Image.ANTIALIAS)
+                                         Image.Resampling.LANCZOS)
             else:
-                image = image.resize((self.__resize[0], self.__resize[1]), Image.ANTIALIAS)
+                image = image.resize((self.__resize[0], self.__resize[1]), Image.Resampling.LANCZOS)
             if self.__channel == 1:
                 image = image.convert('L')
             else:


### PR DESCRIPTION
Starting from version 9.0.0 of Pillow, `Image.ANTIALIAS` has been deprecated and the use of `Image.Resampling.LANCZOS` is recommended instead.