### PR TITLE
vendor: update python requires for all 3.x from 3.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,11 +29,12 @@ setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
     install_requires=['numpy', 'onnxruntime', 'Pillow', 'opencv-python-headless'],
-    python_requires='<3.13',
+    python_requires='>=3.7,<4',
     include_package_data=True,
     install_package_data=True,
 )


### PR DESCRIPTION
1. make the library support Python `3.x` from `3.7`
2. update the declared supported versions in classifiers