### PR TITLE
version unify

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
-    install_requires=['numpy<2.0.0', 'onnxruntime', 'Pillow', 'opencv-python==3.4.16.59'],
+    install_requires=['numpy<2.0.0', 'onnxruntime', 'Pillow', 'opencv-python-headless==3.4.16.59'],
     python_requires='<3.13',
     include_package_data=True,
     install_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
-    install_requires=['numpy', 'onnxruntime', 'Pillow', 'opencv-python-headless'],
+    install_requires=['numpy<2.0.0', 'onnxruntime', 'Pillow', 'opencv-python==3.4.16.59'],
     python_requires='<3.13',
     include_package_data=True,
     install_package_data=True,


### PR DESCRIPTION
内外的版本需要保持一致，实测macos的python3.9，默认安装会安装到4.x版本的opencv，但这个是不支持的，所以需要内外版本保持一致，限定pip的安装版本